### PR TITLE
feat: strict-transport-security

### DIFF
--- a/packages/solution/host.json
+++ b/packages/solution/host.json
@@ -11,5 +11,13 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[3.*, 4.0.0)"
+  },
+  "extensions": {
+    "http": {
+      "routePrefix": "api",
+      "customHeaders": {
+        "strict-transport-security": "max-age=31536000; includeSubDomains"
+      }
+    }
   }
 }


### PR DESCRIPTION
TC-426

Safety: These same settings worked when I applied them to the solutions in the monorepo. (As verified by some random testing site for the `strict-transport-security` header.)